### PR TITLE
Old unfucks ashies

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -203,11 +203,11 @@
 /area/ruin/lavaland/unpowered/ash_walkers)
 "eZ" = (
 /obj/structure/table/wood/shadow,
-/obj/item/cultivator{
+/obj/item/cultivator/bone{
 	pixel_x = -6;
 	pixel_y = -5
 	},
-/obj/item/shovel/spade{
+/obj/item/shovel/spade/bone{
 	pixel_x = -19
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,

--- a/code/__DEFINES/zeros/species.dm
+++ b/code/__DEFINES/zeros/species.dm
@@ -1,2 +1,2 @@
-#define SPECIES_ASHWALKER_WEST "ashlizard_east"
-#define SPECIES_ASHWALKER_EAST "ashlizard_west"
+#define SPECIES_ASHWALKER_WEST "ashlizard_west"
+#define SPECIES_ASHWALKER_EAST "ashlizard_east"

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -36,6 +36,7 @@
 
 //Ash walker eggs: Spawns in ash walker dens in lavaland. Ghosts become unbreathing lizards that worship the Necropolis and are advised to retrieve corpses to create more ash walkers.
 
+/* tempt edit - moved to modular to avoid mosley's fuckery
 /obj/structure/ash_walker_eggshell
 	name = "ash walker egg"
 	desc = "A man-sized yellow egg, spawned from some unfathomable creature. A humanoid silhouette lurks within. The egg shell looks resistant to temperature but otherwise rather brittle."
@@ -141,6 +142,7 @@
 	name ="Ashwalker"
 	head = /obj/item/clothing/head/helmet/gladiator
 	uniform = /obj/item/clothing/under/costume/gladiator/ash_walker
+*/
 
 
 //Timeless prisons: Spawns in Wish Granter prisons in lavaland. Ghosts become age-old users of the Wish Granter and are advised to seek repentance for their past.
@@ -903,3 +905,6 @@
 	new /obj/item/clothing/mask/chameleon(src)
 	new /obj/item/storage/backpack/chameleon(src)
 	new /obj/item/clothing/neck/cloak/chameleon(src)
+
+//tempt edit
+#undef spawnOverride //mosley i will slap you

--- a/code/modules/ruins/objects_and_mobs/ash_walker_den.dm
+++ b/code/modules/ruins/objects_and_mobs/ash_walker_den.dm
@@ -1,3 +1,4 @@
+/*moved to modular tempt for cleanness.
 #define ASH_WALKER_SPAWN_THRESHOLD 2
 //The ash walker den consumes corpses or unconscious mobs to create ash walker eggs. For more info on those, check ghost_role_spawners.dm
 /obj/structure/lavaland/ash_walker
@@ -106,3 +107,4 @@
 		new /obj/effect/mob_spawn/human/ash_walker(get_step(loc, pick(GLOB.alldirs)), ashies)
 		visible_message("<span class='danger'>One of the eggs swells to an unnatural size and tumbles free. It's ready to hatch!</span>")
 		meat_counter -= ASH_WALKER_SPAWN_THRESHOLD
+*/

--- a/modular_splurt/code/game/object/structures/ghost_role_spawners.dm
+++ b/modular_splurt/code/game/object/structures/ghost_role_spawners.dm
@@ -1,5 +1,6 @@
+/* moved to modular tempt
 /obj/effect/mob_spawn/human/ash_walker
-	var/gender_bias
+	var/gender_bias //gg mos you broke it
 
 /obj/effect/mob_spawn/human/ash_walker/equip(mob/living/carbon/human/H)
 	if(!isnull(gender_bias) && prob(90))
@@ -24,6 +25,7 @@
 	Ensure the safety of your nest, let no abomination even graze your home."
 	mob_species = /datum/species/lizard/ashwalker/eastern
 	gender_bias = MALE
+*/
 
 //Portable dangerous-environment sleepers: Spawns in exposed to ash storms shelter.
 //Characters in this role could have been conscious for a long time, surviving on the planet. They may also know Draconic language by contacting with ashwalkers.

--- a/modular_splurt/code/modules/ruins/objects_and_mobs/ash_walker_den.dm
+++ b/modular_splurt/code/modules/ruins/objects_and_mobs/ash_walker_den.dm
@@ -1,3 +1,4 @@
+/* moved to modular for cleanness
 /obj/structure/lavaland/ash_walker/western
 	spawned_obj = /obj/effect/mob_spawn/human/ash_walker/western
 	species = /datum/species/lizard/ashwalker/western
@@ -5,3 +6,4 @@
 /obj/structure/lavaland/ash_walker/eastern
 	spawned_obj = /obj/effect/mob_spawn/human/ash_walker/eastern
 	species = /datum/species/lizard/ashwalker/eastern
+*/

--- a/modular_tempt/code/modules/ashwalkers/clothing.dm
+++ b/modular_tempt/code/modules/ashwalkers/clothing.dm
@@ -1,0 +1,5 @@
+//yep. a standalone file for one outfit. hopefully that'll change in the future.
+/datum/outfit/ashwalker
+	name = "Ashwalker"
+	head = /obj/item/clothing/head/helmet/gladiator
+	uniform = /obj/item/clothing/under/costume/gladiator/ash_walker

--- a/modular_tempt/code/modules/ashwalkers/spawner.dm
+++ b/modular_tempt/code/modules/ashwalkers/spawner.dm
@@ -1,0 +1,124 @@
+/obj/effect/mob_spawn/human/ash_walker
+	name = "ash walker egg"
+	desc = "A man-sized yellow egg, spawned from some unfathomable creature. A humanoid silhouette lurks within."
+	mob_name = "an ash walker"
+	job_description = "Ashwalker"
+	icon = 'icons/mob/lavaland/lavaland_monsters.dmi'
+	icon_state = "large_egg"
+	mob_species = /datum/species/lizard/ashwalker
+	roundstart = FALSE
+	death = FALSE
+	anchored = FALSE
+	move_resist = MOVE_FORCE_NORMAL
+	density = FALSE
+	short_desc = "You are an ash walker. Your tribe worships the Necropolis."
+	flavour_text = "The wastes are sacred ground, its monsters a blessed bounty. You would never willingly leave your homeland behind. \
+	You have seen lights in the distance... they foreshadow the arrival of outsiders to your domain. \
+	Ensure your nest remains protected at all costs."
+	assignedrole = "Ash Walker"
+	var/datum/team/ashwalkers/egg_team
+	var/obj/structure/ash_walker_eggshell/eggshell
+	var/gender_bias
+
+/obj/effect/mob_spawn/human/ash_walker/Initialize(mapload, datum/team/ashwalkers/ashteam)
+	. = ..()
+	var/area/A = get_area(src)
+	egg_team = ashteam
+	eggshell = new /obj/structure/ash_walker_eggshell(get_turf(loc))
+	eggshell.yolk = src
+	src.forceMove(eggshell)
+	if(A)
+		notify_ghosts("An ash walker egg is ready to hatch in \the [A.name].", source = src, action=NOTIFY_ATTACK, flashwindow = FALSE, ignore_key = POLL_IGNORE_ASHWALKER, ignore_dnr_observers = TRUE)
+
+/obj/effect/mob_spawn/human/ash_walker/Destroy()
+	eggshell = null
+	return ..()
+
+/obj/effect/mob_spawn/human/ash_walker/equip(mob/living/carbon/human/H)
+	if(!isnull(gender_bias) && prob(90))
+		H.gender = gender_bias
+	return ..()
+
+/obj/effect/mob_spawn/human/ash_walker/special(mob/living/new_spawn)
+	new_spawn.real_name = random_unique_lizard_name(gender)
+	if(is_mining_level(eggshell.z))
+		to_chat(new_spawn, "<b>Drag the corpses of men and beasts to your nest. It will absorb them to create more of your kind. Glory to the Necropolis!</b>")
+	else
+		to_chat(new_spawn, "<span class='userdanger'>You have been born outside of your natural home! Whether you decide to return home, or make due with your new home is your own decision.</span>")
+
+	if(!ishuman(new_spawn))
+		return
+
+	var/mob/living/carbon/human/H = new_spawn
+	H.underwear = "Nude"
+	H.undershirt = "Nude"
+	H.socks = "Nude"
+	H.update_body()
+	if(egg_team)
+		new_spawn.mind.add_antag_datum(/datum/antagonist/ashwalker, egg_team)
+		egg_team.players_spawned += (new_spawn.key)
+
+	eggshell.yolk = null
+	QDEL_NULL(eggshell)
+
+/obj/effect/mob_spawn/human/ash_walker/western
+	job_description = "Western Ashwalker"
+	short_desc = "You are a Farlander. Your tribe worships the home tendril."
+	flavour_text = "Your original home and tribe razed by Calamity, whoever remained set off to find a new place to live - \
+	these ashen grounds making for a good staying place, filled with flora and huntmeat alike. You're not alone here however, these grounds' natives \
+	restless about your tribe's arrival. Though surely they can be reasoned with.. right?\n\n\
+	Ensure the safety of your tribe. The elders didn't sacrifice themselves for it to perish here."
+	mob_species = /datum/species/lizard/ashwalker/western
+	gender_bias = FEMALE
+
+/obj/effect/mob_spawn/human/ash_walker/eastern
+	job_description = "Eastern Ashwalker"
+	flavour_text = "You've shelter in the Necropolis, it's sacred walls housing your nest, bringing in new kin for your tribe and breathing new life \
+	into your fallen bretheren. Recently however, a foreign tribe came to these grounds, their foul hands threatening your hunt - furthermore, the sky's angels \
+	descend onto these lands, demise of this world as their goal.\n\n\
+	Ensure the safety of your nest, let no abomination even graze your home."
+	mob_species = /datum/species/lizard/ashwalker/eastern
+	gender_bias = MALE
+
+
+
+/obj/structure/ash_walker_eggshell
+	name = "ash walker egg"
+	desc = "A man-sized yellow egg, spawned from some unfathomable creature."
+	icon = 'icons/mob/lavaland/lavaland_monsters.dmi'
+	icon_state = "large_egg"
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | FREEZE_PROOF
+	max_integrity = 80
+	var/obj/effect/mob_spawn/human/ash_walker/yolk
+
+/obj/structure/ash_walker_eggshell/Destroy()
+	if(!yolk)
+		return ..()
+	var/mob/living/carbon/human/giblets = new /mob/living/carbon/human/(get_turf(src))
+	giblets.fully_replace_character_name(null,random_unique_lizard_name(gender))
+	giblets.set_species(/datum/species/lizard/ashwalker)
+	giblets.underwear = "Nude"
+	giblets.update_body()
+	giblets.gib()
+	QDEL_NULL(yolk)
+	return ..()
+
+/obj/structure/ash_walker_eggshell/attack_ghost(mob/user)
+	if(yolk) //Pass on ghost clicks to the mob spawner
+		yolk.attack_ghost(user)
+	. = ..()
+
+/obj/structure/ash_walker_eggshell/examine(mob/user)
+	. = ..()
+	. += yolk ? "A humanoid sillouette lurks within." : "It looks.. hollow inside."
+
+/obj/structure/ash_walker_eggshell/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0) //lifted from xeno eggs
+	switch(damage_type)
+		if(BRUTE)
+			if(damage_amount)
+				playsound(loc, 'sound/effects/attackblob.ogg', 100, TRUE)
+			else
+				playsound(src, 'sound/weapons/tap.ogg', 50, TRUE)
+		if(BURN)
+			if(damage_amount)
+				playsound(loc, 'sound/items/welder.ogg', 100, TRUE)

--- a/modular_tempt/code/modules/ashwalkers/tendrils.dm
+++ b/modular_tempt/code/modules/ashwalkers/tendrils.dm
@@ -1,0 +1,118 @@
+#define ASH_WALKER_SPAWN_THRESHOLD 2
+//The ash walker den consumes corpses or unconscious mobs to create ash walker eggs. For more info on those, check ghost_role_spawners.dm
+/obj/structure/lavaland/ash_walker
+	name = "necropolis tendril nest"
+	desc = "A vile tendril of corruption. It's surrounded by a nest of rapidly growing eggs..."
+	icon = 'icons/mob/nest.dmi'
+	icon_state = "ash_walker_nest"
+	move_resist=INFINITY // just killing it tears a massive hole in the ground, let's not move it
+	anchored = TRUE
+	density = TRUE
+	resistance_flags = FIRE_PROOF | LAVA_PROOF
+	max_integrity = 200
+	var/faction = list("ashwalker")
+	var/meat_counter = 6
+	var/spawned_egg = /obj/effect/mob_spawn/human/ash_walker
+	var/spawned_species = /datum/species/lizard/ashwalker
+
+	var/datum/team/linked_team
+
+/obj/structure/lavaland/ash_walker/Initialize(mapload)
+	.=..()
+	var/datum/objective/protect_object/objective = new /datum/objective/protect_object(src)
+	objective.set_target(src)
+
+	linked_team = new /datum/team/ashwalkers()
+	linked_team.objectives += objective
+
+	//it somewhat annoys me and could be redone by just listening to the neighbor tiles' on-enter signal
+	//but this works for now
+	START_PROCESSING(SSprocessing, src)
+
+/obj/structure/lavaland/ash_walker/Destroy()
+	linked_team = null
+
+	STOP_PROCESSING(SSprocessing, src)
+	return ..()
+
+/obj/structure/lavaland/ash_walker/deconstruct(disassembled)
+	new /obj/item/assembly/signaler/anomaly (get_step(loc, pick(GLOB.alldirs)))
+	new /obj/effect/collapse(loc)
+	return ..()
+
+/obj/structure/lavaland/ash_walker/process()
+	consume()
+	spawn_mob()
+
+/obj/structure/lavaland/ash_walker/proc/consume()
+	for(var/mob/living/H in view(src, 1)) //Only for corpse right next to/on same tile
+		if(!H.stat)
+			continue
+
+		for(var/obj/item/W in H)
+			if(!H.dropItemToGround(W))
+				qdel(W)
+
+		var/mob_mind = H.mind
+		if(mob_mind && (mob_mind in linked_team.members) && (H.key || H.get_ghost(FALSE, TRUE))) //this does mean cross-tribe sacrifices, yes
+			visible_message(span_warning("Serrated tendrils carefully pull [H] to [src], absorbing the body and creating it anew."))
+			var/who_to_bother = H.key ? H : H.get_ghost(FALSE, TRUE)
+			to_chat(who_to_bother, "Your body has been returned to the nest. You are being remade anew, and will awaken shortly. </br><b>Your memories will remain intact in your new body, as your soul is being salvaged.</b>")
+
+			playsound(src, sound('sound/magic/enter_blood.ogg'), )
+			SEND_SOUND(who_to_bother, sound('sound/magic/enter_blood.ogg',volume=100))
+
+			addtimer(CALLBACK(src, .proc/remake_walker, mob_mind, H.real_name, H.gender), 20 SECONDS)
+			new /obj/effect/gibspawner/generic(get_turf(H))
+			qdel(H)
+			continue
+
+		if(issilicon(H)) //no advantage to sacrificing borgs...
+			H.gib()
+			visible_message(span_notice("Serrated tendrils eagerly pull [H] apart, but find nothing of interest."))
+			continue
+
+		playsound(get_turf(src),'sound/magic/demon_consume.ogg', 100, TRUE)
+		visible_message(span_warning("Serrated tendrils eagerly pull [H] to [src], tearing the body apart as its blood seeps over the eggs."))
+
+		meat_counter += ismegafauna(H) ? 20 : 1
+		H.gib()
+
+		obj_integrity = min(obj_integrity + max_integrity*0.05,max_integrity)//restores 5% hp of tendril
+
+		for(var/mob/living/L in view(src, 5))
+			if(L.mind?.has_antag_datum(/datum/antagonist/ashwalker))
+				SEND_SIGNAL(L, COMSIG_ADD_MOOD_EVENT, "headspear", /datum/mood_event/sacrifice_good)
+			else
+				SEND_SIGNAL(L, COMSIG_ADD_MOOD_EVENT, "headspear", /datum/mood_event/sacrifice_bad)
+
+/obj/structure/lavaland/ash_walker/proc/remake_walker(datum/mind/oldmind, oldname, oldgender)
+	var/mob/living/carbon/human/M = new /mob/living/carbon/human(get_step(loc, pick(GLOB.alldirs)))
+	M.set_species(spawned_species)
+	M.real_name = oldname
+	M.gender = oldgender
+	M.underwear = "Nude"
+	M.undershirt = "Nude"
+	M.socks = "Nude"
+	M.update_body()
+	M.remove_language(/datum/language/common)
+	oldmind.transfer_to(M)
+	M.mind.grab_ghost()
+	to_chat(M, "<b>You have been pulled back from beyond the grave, with a new body and renewed purpose. Glory to the Necropolis!</b>")
+	playsound(get_turf(M),'sound/magic/exit_blood.ogg', 100, TRUE)
+
+/obj/structure/lavaland/ash_walker/proc/spawn_mob()
+	if(meat_counter < ASH_WALKER_SPAWN_THRESHOLD)
+		return
+	new spawned_egg(get_step(loc, pick(GLOB.alldirs)), linked_team)
+	visible_message("<span class='danger'>One of the eggs swells to an unnatural size and tumbles free. It's ready to hatch!</span>")
+	meat_counter -= ASH_WALKER_SPAWN_THRESHOLD
+
+
+/obj/structure/lavaland/ash_walker/western
+	spawned_egg = /obj/effect/mob_spawn/human/ash_walker/western
+	spawned_species = /datum/species/lizard/ashwalker/western
+
+/obj/structure/lavaland/ash_walker/eastern
+	spawned_egg = /obj/effect/mob_spawn/human/ash_walker/eastern
+	spawned_species = /datum/species/lizard/ashwalker/eastern

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4520,5 +4520,8 @@
 #include "modular_splurt\code\modules\vending\kinkmate.dm"
 #include "modular_splurt\code\modules\vending\security.dm"
 #include "modular_splurt\code\modules\vending\wardrobes.dm"
+#include "modular_tempt\code\modules\ashwalkers\clothing.dm"
+#include "modular_tempt\code\modules\ashwalkers\spawner.dm"
+#include "modular_tempt\code\modules\ashwalkers\tendrils.dm"
 #include "tools\Redirector\textprocs.dm"
 // END_INCLUDE


### PR DESCRIPTION
# About The Pull Request

-fixes ashies showing up as "spawning outside of home" despite being on lavaland
-fixes gladiator being improperly racist towards both tribes
-fixes ashies not using their respective species and several issues resulting thereof
-fixes ashies being able to respawn via other tribes' tendrils
-fixes an annoying define swap
-west tribe now spawns with bone gardening tools instead of station ones
-undefs a rouge mosley define
-ashwalker eggs now display if they have a mob spawn inside them (probably won't be used)

## Why It's Good For The Game

bugs bad

## Changelog

:cl:
fix: fixed several bugs regarding ashwalkers
/:cl:
