### PR TITLE
Remove Blueshield Alt Title

### DIFF
--- a/modular_splurt/code/modules/jobs/job_types/blueshield.dm
+++ b/modular_splurt/code/modules/jobs/job_types/blueshield.dm
@@ -14,7 +14,7 @@
 	exp_type = EXP_TYPE_COMMAND
 	considered_combat_role = TRUE //Brigger then shit yes it is
 	exp_type_department = EXP_TYPE_COMMAND
-	alt_titles = list("Command Security", "Command Guard", "Command Bodyguard", "Blueguard", "Blueshit")
+	alt_titles = list("Command Security", "Command Guard", "Command Bodyguard", "Blueguard", "Blueshit") //overridden in modular_tempt
 	custom_spawn_text = "<font color='red' size='4'><b> YOU ARE NOT PART OF COMMAND. YOU WILL NEVER BE PART OF COMMAND. YOU ARE NOT PART OF CENTRAL COMMAND. IF YOU ACT LIKE YOU ARE, YOU WILL NEVER PLAY BLUESHIELD EVER AGAIN.</b></font>"
 
 	outfit = /datum/outfit/job/blueshield

--- a/modular_tempt/code/modules/jobs/alt_titles.dm
+++ b/modular_tempt/code/modules/jobs/alt_titles.dm
@@ -1,0 +1,2 @@
+/datum/job/blueshield
+	alt_titles = list("Command Security", "Command Guard", "Command Bodyguard", "Blueguard")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4524,5 +4524,6 @@
 #include "modular_splurt\code\modules\vending\kinkmate.dm"
 #include "modular_splurt\code\modules\vending\security.dm"
 #include "modular_splurt\code\modules\vending\wardrobes.dm"
+#include "modular_tempt\code\modules\jobs\alt_titles.dm"
 #include "tools\Redirector\textprocs.dm"
 // END_INCLUDE


### PR DESCRIPTION
# About The Pull Request
Removes alternate "Blueshit" title for Blueshield job.

## Why It's Good For The Game

No one would hire a "Blueshit".

## A Port?

No.

## Changelog

:cl:
del: removed "blueshit" from possible blueshield alt titles
/:cl: