### PR TITLE
Respawn Text Change

### DIFF
--- a/code/modules/mob/dead/observer/respawn.dm
+++ b/code/modules/mob/dead/observer/respawn.dm
@@ -159,9 +159,13 @@
 	log_game("[key_name(src)] was respawned to lobby [penalize? "with" : "without"] restrictions.")
 	var/mob/dead/new_player/N = transfer_to_lobby()
 
+/* tempt edit begin
 	to_chat(N, "<span class='userdanger'>You have been respawned to the lobby. \
 	Remember to take heed of rules regarding round knowledge - notably, that ALL past lives are forgotten. \
 	Any character you join as has NO knowledge of round events unless specified otherwise by an admin.</span>")
+*/
+	to_chat(N, span_bold("Please roleplay correctly!"))
+//tempt edit end
 
 /**
  * Actual proc that removes us and puts us back on lobby


### PR DESCRIPTION
# About The Pull Request

Simplifies the wall of text pasted on respawning to a simple "Please roleplay correctly."

## Why It's Good For The Game

We're not housing children here, are we?

## A Port?

Nuh.

## Changelog

:cl:
spellcheck: tweaked the respawn text
/:cl:
