### PR TITLE
Titanium Floors Icon State Quickfix

### DIFF
--- a/modular_tempt/code/game/turfs/simulated/floor/mineral_floor.dm
+++ b/modular_tempt/code/game/turfs/simulated/floor/mineral_floor.dm
@@ -1,0 +1,2 @@
+/turf/open/floor/mineral/titanium
+	broken_states = list("titanium_dam2","titanium_dam3","titanium_dam4","titanium_dam5") //there's no titanium_dam1 iconstate.

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4525,5 +4525,6 @@
 #include "modular_splurt\code\modules\vending\security.dm"
 #include "modular_splurt\code\modules\vending\wardrobes.dm"
 #include "modular_tempt\code\modules\jobs\alt_titles.dm"
+#include "modular_tempt\code\game\turfs\simulated\floor\mineral_floor.dm"
 #include "tools\Redirector\textprocs.dm"
 // END_INCLUDE


### PR DESCRIPTION
# About The Pull Request

Titanium floors pointed to an invalid icon state. This fixes that.

## Why It's Good For The Game

This is SS13, not CS:GO.

## Changelog

:cl:
fix: removed titanium floors referencing an invalid texture
/:cl:
