### PR TITLE
Update Changelog.js

### DIFF
--- a/tgui/packages/tgui/interfaces/Changelog.js
+++ b/tgui/packages/tgui/interfaces/Changelog.js
@@ -175,7 +175,7 @@ export class Changelog extends Component {
 
     const header = (
       <Section>
-        <h1>S.P.L.U.R.T. Station 13</h1>
+        <h1>TemptStation 13</h1>
         <p>
           <b>Thanks to: </b>
           Citadel Station 13, /tg/station, Baystation 12, /vg/station,
@@ -186,17 +186,17 @@ export class Changelog extends Component {
         </p>
         <p>
           {'Current project maintainers can be found '}
-          <a href="https://github.com/SPLURT-Station/S.P.L.U.R.T-Station-13/graphs/contributors">
+          <a href="https://github.com/TemptStation/TemptStation/graphs/contributors">
             here
           </a>
           {', recent GitHub contributors can be found '}
-          <a href="https://github.com/SPLURT-Station/S.P.L.U.R.T-Station-13/pulse/monthly">
+          <a href="https://github.com/TemptStation/TemptStation/pulse/monthly">
             here
           </a>.
         </p>
         <p>
           {'You can also join our discord '}
-          <a href="https://discord.com/invite/wynHVMzHzC">
+          <a href="https://discord.gg/VhDRKNKYmT">
             here
           </a>.
         </p>


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your PR is related to one of our discord suggestions, please add the number of this suggestion to this section. Or if you may, the message link of said suggestion-->

Personalize Changelog.js for TemptStation.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Displays our codebase/server's information instead of our upstream's.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:
tweak: Changelog.js
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
