### PR TITLE
Anchorable Plants

### DIFF
--- a/_maps/shuttles/access_smol.dmm
+++ b/_maps/shuttles/access_smol.dmm
@@ -64,7 +64,6 @@
 /area/shuttle/access_smol)
 "F" = (
 /obj/structure/closet/emcloset/anchored,
-/obj/structure/closet/emcloset/anchored,
 /obj/machinery/light/small{
 	dir = 1
 	},

--- a/_maps/shuttles/arrival_delta.dmm
+++ b/_maps/shuttles/arrival_delta.dmm
@@ -121,13 +121,17 @@
 	name = "protective hat";
 	pixel_y = 9
 	},
-/obj/structure/closet/crate/internals,
+/obj/structure/closet/crate/internals{
+	anchored = 1
+	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/shuttle/arrival)
 "j" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/closet/wardrobe/mixed,
+/obj/structure/closet/wardrobe/mixed{
+	anchored = 1
+	},
 /turf/open/floor/plasteel,
 /area/shuttle/arrival)
 "k" = (
@@ -204,6 +208,7 @@
 	pixel_x = -32
 	},
 /obj/item/kirbyplants{
+	anchored = 1;
 	icon_state = "plant-21"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -227,6 +232,7 @@
 	pixel_x = 32
 	},
 /obj/item/kirbyplants{
+	anchored = 1;
 	icon_state = "plant-21"
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -278,6 +284,7 @@
 /area/shuttle/arrival)
 "A" = (
 /obj/item/kirbyplants{
+	anchored = 1;
 	icon_state = "plant-21"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -313,6 +320,7 @@
 /area/shuttle/arrival)
 "E" = (
 /obj/item/kirbyplants{
+	anchored = 1;
 	icon_state = "plant-21"
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -348,7 +356,9 @@
 /turf/open/floor/plasteel,
 /area/shuttle/arrival)
 "H" = (
-/obj/structure/closet/wardrobe/black,
+/obj/structure/closet/wardrobe/black{
+	anchored = 1
+	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -356,7 +366,9 @@
 /turf/open/floor/plasteel,
 /area/shuttle/arrival)
 "I" = (
-/obj/structure/closet/wardrobe/grey,
+/obj/structure/closet/wardrobe/grey{
+	anchored = 1
+	},
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/shuttle/arrival)
@@ -368,14 +380,18 @@
 /turf/open/floor/plasteel,
 /area/shuttle/arrival)
 "K" = (
-/obj/structure/closet/wardrobe/yellow,
+/obj/structure/closet/wardrobe/yellow{
+	anchored = 1
+	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/shuttle/arrival)
 "L" = (
-/obj/structure/closet/wardrobe/grey,
+/obj/structure/closet/wardrobe/grey{
+	anchored = 1
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},

--- a/_maps/shuttles/arrival_kilo.dmm
+++ b/_maps/shuttles/arrival_kilo.dmm
@@ -65,7 +65,9 @@
 	name = "protective hat";
 	pixel_y = 9
 	},
-/obj/structure/closet/crate/internals,
+/obj/structure/closet/crate/internals{
+	anchored = 1
+	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/arrival)

--- a/_maps/shuttles/arrival_omega.dmm
+++ b/_maps/shuttles/arrival_omega.dmm
@@ -138,7 +138,9 @@
 /turf/open/floor/plasteel,
 /area/shuttle/arrival)
 "o" = (
-/obj/item/kirbyplants/random,
+/obj/item/kirbyplants/random{
+	anchored = 1
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -201,7 +203,9 @@
 /turf/open/floor/plasteel,
 /area/shuttle/arrival)
 "w" = (
-/obj/structure/closet/crate/internals,
+/obj/structure/closet/crate/internals{
+	anchored = 1
+	},
 /obj/item/storage/firstaid/o2,
 /obj/item/tank/internals/emergency_oxygen,
 /obj/item/tank/internals/emergency_oxygen,

--- a/_maps/shuttles/arrival_pubby.dmm
+++ b/_maps/shuttles/arrival_pubby.dmm
@@ -37,11 +37,15 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "h" = (
-/obj/structure/closet/wardrobe/black,
+/obj/structure/closet/wardrobe/black{
+	anchored = 1
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "i" = (
-/obj/structure/closet/wardrobe/mixed,
+/obj/structure/closet/wardrobe/mixed{
+	anchored = 1
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "j" = (
@@ -113,7 +117,9 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/arrival)
 "s" = (
-/obj/structure/closet/emcloset,
+/obj/structure/closet/emcloset{
+	anchored = 1
+	},
 /obj/item/storage/firstaid/o2,
 /obj/item/tank/internals/emergency_oxygen,
 /obj/item/clothing/mask/breath,

--- a/_maps/shuttles/arrival_smol.dmm
+++ b/_maps/shuttles/arrival_smol.dmm
@@ -9,7 +9,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/item/kirbyplants/random,
+/obj/item/kirbyplants/random{
+	anchored = 1
+	},
 /turf/open/floor/plasteel,
 /area/shuttle/arrival)
 "g" = (
@@ -85,7 +87,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/structure/closet/crate/internals,
+/obj/structure/closet/crate/internals{
+	anchored = 1
+	},
 /obj/item/storage/firstaid/o2,
 /obj/item/tank/internals/emergency_oxygen,
 /obj/item/tank/internals/emergency_oxygen,

--- a/_maps/shuttles/arrival_snaxi.dmm
+++ b/_maps/shuttles/arrival_snaxi.dmm
@@ -17,7 +17,9 @@
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 "e" = (
-/obj/structure/closet/wardrobe/black,
+/obj/structure/closet/wardrobe/black{
+	anchored = 1
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "f" = (
@@ -28,14 +30,18 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "h" = (
-/obj/structure/closet/wardrobe/grey,
+/obj/structure/closet/wardrobe/grey{
+	anchored = 1
+	},
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "i" = (
-/obj/structure/closet/wardrobe/green,
+/obj/structure/closet/wardrobe/green{
+	anchored = 1
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "j" = (
@@ -62,7 +68,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/closet/wardrobe/mixed,
+/obj/structure/closet/wardrobe/mixed{
+	anchored = 1
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "n" = (
@@ -104,7 +112,9 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "x" = (
-/obj/structure/closet/emcloset,
+/obj/structure/closet/emcloset{
+	anchored = 1
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)
 "z" = (

--- a/_maps/shuttles/emergency_asteroid.dmm
+++ b/_maps/shuttles/emergency_asteroid.dmm
@@ -123,7 +123,9 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "aI" = (
-/obj/structure/closet,
+/obj/structure/closet{
+	anchored = 1
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "aJ" = (
@@ -146,7 +148,9 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "aM" = (
-/obj/structure/closet/emcloset,
+/obj/structure/closet/emcloset{
+	anchored = 1
+	},
 /obj/item/radio/intercom{
 	broadcasting = 0;
 	name = "Station Intercom (General)";
@@ -343,7 +347,9 @@
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "bv" = (
-/obj/structure/closet/emcloset,
+/obj/structure/closet/emcloset{
+	anchored = 1
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "bw" = (
@@ -387,7 +393,9 @@
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "bD" = (
-/obj/structure/closet/secure_closet/medical2,
+/obj/structure/closet/secure_closet/medical2{
+	anchored = 1
+	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "bE" = (

--- a/_maps/shuttles/emergency_bar.dmm
+++ b/_maps/shuttles/emergency_bar.dmm
@@ -18,7 +18,9 @@
 /area/shuttle/escape)
 "af" = (
 /obj/structure/table/wood,
-/obj/item/flashlight/lamp/green,
+/obj/item/flashlight/lamp/green{
+	anchored = 1
+	},
 /turf/open/floor/carpet,
 /area/shuttle/escape)
 "ag" = (
@@ -176,6 +178,7 @@
 	pixel_y = 24
 	},
 /obj/item/kirbyplants{
+	anchored = 1;
 	icon_state = "plant-21";
 	pixel_x = -3;
 	pixel_y = 3
@@ -386,6 +389,7 @@
 /area/shuttle/escape)
 "bc" = (
 /obj/item/kirbyplants{
+	anchored = 1;
 	icon_state = "plant-21";
 	pixel_x = -3;
 	pixel_y = 3
@@ -425,6 +429,7 @@
 /area/shuttle/escape)
 "bg" = (
 /obj/item/kirbyplants{
+	anchored = 1;
 	icon_state = "plant-10"
 	},
 /obj/effect/turf_decal/tile/bar,
@@ -558,6 +563,7 @@
 /area/shuttle/escape)
 "bG" = (
 /obj/item/kirbyplants{
+	anchored = 1;
 	icon_state = "plant-21";
 	pixel_x = -3;
 	pixel_y = 3

--- a/_maps/shuttles/emergency_birdboat.dmm
+++ b/_maps/shuttles/emergency_birdboat.dmm
@@ -48,6 +48,7 @@
 /area/shuttle/escape)
 "k" = (
 /obj/item/kirbyplants{
+	anchored = 1;
 	icon_state = "plant-22"
 	},
 /turf/open/floor/mineral/titanium/blue,
@@ -145,6 +146,7 @@
 /area/shuttle/escape)
 "B" = (
 /obj/item/kirbyplants{
+	anchored = 1;
 	icon_state = "plant-21"
 	},
 /turf/open/floor/mineral/titanium,

--- a/_maps/shuttles/emergency_box.dmm
+++ b/_maps/shuttles/emergency_box.dmm
@@ -156,7 +156,9 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "aD" = (
-/obj/structure/closet/emcloset,
+/obj/structure/closet/emcloset{
+	anchored = 1
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "aE" = (
@@ -294,11 +296,15 @@
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "bf" = (
-/obj/structure/closet,
+/obj/structure/closet{
+	anchored = 1
+	},
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "bg" = (
-/obj/structure/closet/crate,
+/obj/structure/closet/crate{
+	anchored = 1
+	},
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "bi" = (
@@ -370,7 +376,9 @@
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "XC" = (
-/obj/structure/closet/emcloset,
+/obj/structure/closet/emcloset{
+	anchored = 1
+	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "ZQ" = (

--- a/_maps/shuttles/emergency_cere.dmm
+++ b/_maps/shuttles/emergency_cere.dmm
@@ -421,6 +421,7 @@
 /area/shuttle/escape)
 "aM" = (
 /obj/item/kirbyplants{
+	anchored = 1;
 	icon_state = "plant-22"
 	},
 /obj/item/radio/intercom{
@@ -447,6 +448,7 @@
 /area/shuttle/escape)
 "aP" = (
 /obj/item/kirbyplants{
+	anchored = 1;
 	icon_state = "plant-22"
 	},
 /obj/item/radio/intercom{
@@ -674,7 +676,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/closet,
+/obj/structure/closet{
+	anchored = 1
+	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -727,7 +731,9 @@
 /area/shuttle/escape)
 "bD" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/closet/crate,
+/obj/structure/closet/crate{
+	anchored = 1
+	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -866,7 +872,9 @@
 /area/shuttle/escape)
 "bP" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/closet,
+/obj/structure/closet{
+	anchored = 1
+	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -969,6 +977,7 @@
 /area/shuttle/escape)
 "ca" = (
 /obj/item/kirbyplants{
+	anchored = 1;
 	icon_state = "plant-21"
 	},
 /turf/open/floor/plasteel,
@@ -995,6 +1004,7 @@
 	dir = 4
 	},
 /obj/item/kirbyplants{
+	anchored = 1;
 	icon_state = "plant-21"
 	},
 /turf/open/floor/plasteel,
@@ -1099,7 +1109,9 @@
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "cn" = (
-/obj/structure/closet/emcloset,
+/obj/structure/closet/emcloset{
+	anchored = 1
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -1464,7 +1476,9 @@
 /turf/open/floor/plasteel/freezer,
 /area/shuttle/escape)
 "cT" = (
-/obj/structure/closet/secure_closet/engineering_personal,
+/obj/structure/closet/secure_closet/engineering_personal{
+	anchored = 1
+	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -1526,7 +1540,9 @@
 /turf/open/floor/plasteel/freezer,
 /area/shuttle/escape)
 "cZ" = (
-/obj/structure/closet/secure_closet/engineering_personal,
+/obj/structure/closet/secure_closet/engineering_personal{
+	anchored = 1
+	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},

--- a/_maps/shuttles/emergency_cramped.dmm
+++ b/_maps/shuttles/emergency_cramped.dmm
@@ -72,7 +72,9 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "m" = (
-/obj/structure/closet/emcloset,
+/obj/structure/closet/emcloset{
+	anchored = 1
+	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "n" = (
@@ -82,7 +84,9 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "o" = (
-/obj/structure/closet/crate,
+/obj/structure/closet/crate{
+	anchored = 1
+	},
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 8;
 	name = "8maintenance loot spawner"
@@ -91,7 +95,9 @@
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
 "p" = (
-/obj/structure/closet/crate/secure/loot,
+/obj/structure/closet/crate/secure/loot{
+	anchored = 1
+	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
@@ -103,7 +109,9 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "r" = (
-/obj/structure/closet/crate/secure/weapon,
+/obj/structure/closet/crate/secure/weapon{
+	anchored = 1
+	},
 /obj/effect/spawner/lootdrop/armory_contraband,
 /obj/effect/turf_decal/bot,
 /obj/machinery/light{
@@ -132,14 +140,18 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
 "v" = (
-/obj/structure/closet/emcloset,
+/obj/structure/closet/emcloset{
+	anchored = 1
+	},
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "w" = (
-/obj/structure/closet/crate/secure/weapon,
+/obj/structure/closet/crate/secure/weapon{
+	anchored = 1
+	},
 /obj/effect/spawner/lootdrop/armory_contraband,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,

--- a/_maps/shuttles/emergency_delta.dmm
+++ b/_maps/shuttles/emergency_delta.dmm
@@ -111,7 +111,9 @@
 	name = "protective hat";
 	pixel_y = 9
 	},
-/obj/structure/closet/crate/internals,
+/obj/structure/closet/crate/internals{
+	anchored = 1
+	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
@@ -168,6 +170,7 @@
 /area/shuttle/escape)
 "an" = (
 /obj/item/kirbyplants{
+	anchored = 1;
 	icon_state = "plant-21";
 	pixel_x = -3;
 	pixel_y = 3
@@ -197,6 +200,7 @@
 /area/shuttle/escape)
 "ap" = (
 /obj/item/kirbyplants{
+	anchored = 1;
 	icon_state = "plant-21";
 	pixel_x = -3;
 	pixel_y = 3
@@ -610,7 +614,7 @@
 /area/shuttle/escape)
 "bd" = (
 /obj/structure/closet/crate/medical{
-	name = "medical crate"
+	anchored = 1
 	},
 /obj/item/storage/firstaid/regular,
 /obj/item/storage/firstaid/o2{
@@ -661,6 +665,7 @@
 /area/shuttle/escape)
 "bi" = (
 /obj/structure/closet/crate{
+	anchored = 1;
 	name = "emergency supplies crate"
 	},
 /obj/item/storage/toolbox/emergency,
@@ -801,6 +806,7 @@
 /area/shuttle/escape)
 "bz" = (
 /obj/item/kirbyplants{
+	anchored = 1;
 	icon_state = "plant-21"
 	},
 /obj/machinery/button/flasher{
@@ -815,6 +821,7 @@
 /area/shuttle/escape)
 "bA" = (
 /obj/item/kirbyplants{
+	anchored = 1;
 	icon_state = "plant-21"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -1019,6 +1026,7 @@
 /area/shuttle/escape)
 "cb" = (
 /obj/item/kirbyplants{
+	anchored = 1;
 	icon_state = "plant-21";
 	pixel_x = -3;
 	pixel_y = 3
@@ -1339,6 +1347,7 @@
 /area/shuttle/escape)
 "cA" = (
 /obj/item/kirbyplants{
+	anchored = 1;
 	icon_state = "plant-21";
 	pixel_x = -3;
 	pixel_y = 3

--- a/_maps/shuttles/emergency_kilo.dmm
+++ b/_maps/shuttles/emergency_kilo.dmm
@@ -328,7 +328,9 @@
 	name = "protective hat";
 	pixel_y = 9
 	},
-/obj/structure/closet/crate/internals,
+/obj/structure/closet/crate/internals{
+	anchored = 1
+	},
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -428,7 +430,9 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "bb" = (
-/obj/structure/closet/emcloset,
+/obj/structure/closet/emcloset{
+	anchored = 1
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -671,6 +675,7 @@
 /area/shuttle/escape)
 "by" = (
 /obj/structure/closet/crate{
+	anchored = 1;
 	name = "emergency supplies crate"
 	},
 /obj/item/storage/toolbox/emergency,
@@ -719,7 +724,7 @@
 /area/shuttle/escape)
 "bC" = (
 /obj/structure/closet/crate/medical{
-	name = "medical crate"
+	anchored = 1
 	},
 /obj/item/storage/firstaid/regular,
 /obj/item/storage/firstaid/o2{
@@ -857,7 +862,9 @@
 	name = "protective hat";
 	pixel_y = 9
 	},
-/obj/structure/closet/crate/internals,
+/obj/structure/closet/crate/internals{
+	anchored = 1
+	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -922,7 +929,9 @@
 	name = "protective hat";
 	pixel_y = 9
 	},
-/obj/structure/closet/crate/internals,
+/obj/structure/closet/crate/internals{
+	anchored = 1
+	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)

--- a/_maps/shuttles/emergency_luxury.dmm
+++ b/_maps/shuttles/emergency_luxury.dmm
@@ -306,6 +306,7 @@
 /area/shuttle/escape/luxury)
 "bg" = (
 /obj/item/kirbyplants{
+	anchored = 1;
 	icon_state = "plant-10"
 	},
 /turf/open/floor/carpet/red,
@@ -321,6 +322,7 @@
 /area/shuttle/escape/luxury)
 "bj" = (
 /obj/item/kirbyplants{
+	anchored = 1;
 	icon_state = "plant-21";
 	pixel_x = -3;
 	pixel_y = 3
@@ -329,12 +331,14 @@
 /area/shuttle/escape/luxury)
 "bk" = (
 /obj/item/kirbyplants{
+	anchored = 1;
 	icon_state = "plant-10"
 	},
 /turf/open/floor/carpet/royalblue,
 /area/shuttle/escape/luxury)
 "bl" = (
 /obj/item/kirbyplants{
+	anchored = 1;
 	icon_state = "plant-21";
 	pixel_x = -3;
 	pixel_y = 3
@@ -438,6 +442,7 @@
 	light_range = 8
 	},
 /obj/item/kirbyplants{
+	anchored = 1;
 	icon_state = "plant-10"
 	},
 /turf/open/floor/carpet/red,

--- a/_maps/shuttles/emergency_meta.dmm
+++ b/_maps/shuttles/emergency_meta.dmm
@@ -68,7 +68,9 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "ap" = (
-/obj/structure/closet/emcloset,
+/obj/structure/closet/emcloset{
+	anchored = 1
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "aq" = (
@@ -167,6 +169,7 @@
 	pixel_y = 9
 	},
 /obj/structure/closet/crate{
+	anchored = 1;
 	name = "lifejackets"
 	},
 /turf/open/floor/mineral/titanium/blue,
@@ -641,6 +644,7 @@
 /area/shuttle/escape)
 "bO" = (
 /obj/structure/closet/crate{
+	anchored = 1;
 	name = "emergency supplies crate"
 	},
 /obj/item/storage/toolbox/emergency,
@@ -661,7 +665,7 @@
 /area/shuttle/escape)
 "bP" = (
 /obj/structure/closet/crate/medical{
-	name = "medical crate"
+	anchored = 1
 	},
 /obj/item/storage/firstaid/regular,
 /obj/item/storage/firstaid/o2{
@@ -801,6 +805,7 @@
 	pixel_y = 9
 	},
 /obj/structure/closet/crate{
+	anchored = 1;
 	name = "lifejackets"
 	},
 /obj/machinery/light{

--- a/_maps/shuttles/emergency_mini.dmm
+++ b/_maps/shuttles/emergency_mini.dmm
@@ -100,7 +100,9 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "s" = (
-/obj/structure/closet/emcloset,
+/obj/structure/closet/emcloset{
+	anchored = 1
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "t" = (

--- a/_maps/shuttles/emergency_narnar.dmm
+++ b/_maps/shuttles/emergency_narnar.dmm
@@ -103,7 +103,9 @@
 /turf/closed/wall/mineral/cult,
 /area/shuttle/escape)
 "t" = (
-/obj/structure/closet/emcloset,
+/obj/structure/closet/emcloset{
+	anchored = 1
+	},
 /turf/open/floor/plasteel/cult,
 /area/shuttle/escape)
 "u" = (

--- a/_maps/shuttles/emergency_omega.dmm
+++ b/_maps/shuttles/emergency_omega.dmm
@@ -195,6 +195,7 @@
 /area/shuttle/escape)
 "as" = (
 /obj/item/kirbyplants{
+	anchored = 1;
 	icon_state = "plant-21";
 	pixel_x = -3;
 	pixel_y = 3
@@ -318,6 +319,7 @@
 /area/shuttle/escape)
 "aC" = (
 /obj/item/kirbyplants{
+	anchored = 1;
 	icon_state = "plant-21";
 	pixel_x = -3;
 	pixel_y = 3
@@ -443,7 +445,9 @@
 	name = "protective hat";
 	pixel_y = 9
 	},
-/obj/structure/closet/crate/internals,
+/obj/structure/closet/crate/internals{
+	anchored = 1
+	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/shuttle/escape)
@@ -531,6 +535,7 @@
 /area/shuttle/escape)
 "aS" = (
 /obj/item/kirbyplants{
+	anchored = 1;
 	icon_state = "plant-21";
 	pixel_x = -3;
 	pixel_y = 3
@@ -583,7 +588,7 @@
 /area/shuttle/escape)
 "aY" = (
 /obj/structure/closet/crate/medical{
-	name = "medical crate"
+	anchored = 1
 	},
 /obj/item/storage/firstaid/regular,
 /obj/item/storage/firstaid/o2{
@@ -680,6 +685,7 @@
 /area/shuttle/escape)
 "bg" = (
 /obj/structure/closet/crate{
+	anchored = 1;
 	name = "emergency supplies crate"
 	},
 /obj/item/storage/toolbox/emergency,

--- a/_maps/shuttles/emergency_pubby.dmm
+++ b/_maps/shuttles/emergency_pubby.dmm
@@ -111,6 +111,7 @@
 	pixel_y = 32
 	},
 /obj/item/kirbyplants{
+	anchored = 1;
 	icon_state = "plant-21";
 	pixel_x = -3;
 	pixel_y = 3
@@ -184,6 +185,7 @@
 "aB" = (
 /obj/structure/window/reinforced,
 /obj/item/kirbyplants{
+	anchored = 1;
 	icon_state = "plant-11"
 	},
 /obj/effect/turf_decal/tile/green,
@@ -252,7 +254,9 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "aG" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/structure/closet/secure_closet/freezer/fridge{
+	anchored = 1
+	},
 /obj/structure/window/reinforced{
 	dir = 8;
 	layer = 2.9
@@ -590,6 +594,7 @@
 /area/shuttle/escape)
 "bu" = (
 /obj/item/kirbyplants{
+	anchored = 1;
 	icon_state = "plant-22"
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,

--- a/_maps/shuttles/emergency_raven.dmm
+++ b/_maps/shuttles/emergency_raven.dmm
@@ -527,7 +527,9 @@
 	name = "protective hat";
 	pixel_y = 9
 	},
-/obj/structure/closet/crate/internals,
+/obj/structure/closet/crate/internals{
+	anchored = 1
+	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -961,7 +963,9 @@
 	name = "protective hat";
 	pixel_y = 9
 	},
-/obj/structure/closet/crate/internals,
+/obj/structure/closet/crate/internals{
+	anchored = 1
+	},
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -1015,6 +1019,7 @@
 /area/shuttle/escape)
 "bV" = (
 /obj/item/kirbyplants{
+	anchored = 1;
 	icon_state = "plant-22"
 	},
 /obj/effect/turf_decal/tile/green{
@@ -1030,6 +1035,7 @@
 /area/shuttle/escape)
 "bW" = (
 /obj/item/kirbyplants{
+	anchored = 1;
 	icon_state = "plant-22"
 	},
 /obj/effect/turf_decal/tile/green{
@@ -1095,6 +1101,7 @@
 /area/shuttle/escape)
 "cd" = (
 /obj/item/kirbyplants{
+	anchored = 1;
 	icon_state = "plant-22"
 	},
 /obj/effect/turf_decal/tile/green{
@@ -1108,6 +1115,7 @@
 /area/shuttle/escape)
 "ce" = (
 /obj/item/kirbyplants{
+	anchored = 1;
 	icon_state = "plant-22"
 	},
 /obj/effect/turf_decal/tile/green,

--- a/_maps/shuttles/emergency_syndicate.dmm
+++ b/_maps/shuttles/emergency_syndicate.dmm
@@ -388,7 +388,9 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "aI" = (
-/obj/structure/closet/syndicate/personal,
+/obj/structure/closet/syndicate/personal{
+	anchored = 1
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -472,7 +474,9 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "aQ" = (
-/obj/structure/closet/syndicate/personal,
+/obj/structure/closet/syndicate/personal{
+	anchored = 1
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -492,7 +496,9 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "aS" = (
-/obj/structure/closet/firecloset,
+/obj/structure/closet/firecloset{
+	anchored = 1
+	},
 /obj/effect/turf_decal/bot_white,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -540,7 +546,9 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "aW" = (
-/obj/structure/closet/emcloset,
+/obj/structure/closet/emcloset{
+	anchored = 1
+	},
 /obj/effect/turf_decal/bot_white,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -617,7 +625,9 @@
 /turf/open/floor/plasteel/recharge_floor,
 /area/shuttle/escape)
 "bf" = (
-/obj/structure/closet/crate/internals,
+/obj/structure/closet/crate/internals{
+	anchored = 1
+	},
 /obj/effect/turf_decal/bot_white,
 /obj/item/clothing/suit/hazardvest{
 	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
@@ -1138,7 +1148,9 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "bX" = (
-/obj/structure/closet/emcloset,
+/obj/structure/closet/emcloset{
+	anchored = 1
+	},
 /obj/effect/turf_decal/bot_white,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -1352,6 +1364,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/item/kirbyplants{
+	anchored = 1;
 	icon_state = "plant-22"
 	},
 /turf/open/floor/plasteel/dark,
@@ -1816,7 +1829,9 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/structure/closet/firecloset,
+/obj/structure/closet/firecloset{
+	anchored = 1
+	},
 /obj/effect/turf_decal/bot_white,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -1843,12 +1858,15 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/item/kirbyplants{
+	anchored = 1;
 	icon_state = "plant-22"
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "cT" = (
-/obj/structure/closet/crate,
+/obj/structure/closet/crate{
+	anchored = 1
+	},
 /obj/effect/turf_decal/stripes/line,
 /obj/item/stack/sheet/metal/fifty,
 /obj/effect/turf_decal/tile/neutral,
@@ -1858,7 +1876,9 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "cU" = (
-/obj/structure/closet/crate,
+/obj/structure/closet/crate{
+	anchored = 1
+	},
 /obj/effect/turf_decal/stripes/line,
 /obj/item/stack/sheet/glass/fifty,
 /obj/effect/turf_decal/tile/neutral,
@@ -1868,7 +1888,9 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "cV" = (
-/obj/structure/closet/syndicate,
+/obj/structure/closet/syndicate{
+	anchored = 1
+	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -1877,7 +1899,9 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "cW" = (
-/obj/structure/closet/syndicate,
+/obj/structure/closet/syndicate{
+	anchored = 1
+	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
@@ -1888,7 +1912,9 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "cX" = (
-/obj/structure/closet/crate/secure/weapon,
+/obj/structure/closet/crate/secure/weapon{
+	anchored = 1
+	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{

--- a/_maps/shuttles/emergency_vault.dmm
+++ b/_maps/shuttles/emergency_vault.dmm
@@ -503,7 +503,9 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/closet/firecloset/full,
+/obj/structure/closet/firecloset/full{
+	anchored = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "DO" = (
@@ -814,7 +816,9 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "Sk" = (
-/obj/structure/closet/firecloset/full,
+/obj/structure/closet/firecloset/full{
+	anchored = 1
+	},
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)

--- a/_maps/shuttles/ferry_base.dmm
+++ b/_maps/shuttles/ferry_base.dmm
@@ -60,7 +60,9 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/transport)
 "p" = (
-/obj/structure/closet/crate,
+/obj/structure/closet/crate{
+	anchored = 1
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/transport)
 "q" = (

--- a/_maps/shuttles/ferry_lighthouse.dmm
+++ b/_maps/shuttles/ferry_lighthouse.dmm
@@ -195,7 +195,9 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/transport)
 "aV" = (
-/obj/structure/closet/crate,
+/obj/structure/closet/crate{
+	anchored = 1
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/transport)
 "aW" = (

--- a/_maps/shuttles/ferry_meat.dmm
+++ b/_maps/shuttles/ferry_meat.dmm
@@ -28,6 +28,7 @@
 /area/shuttle/transport)
 "h" = (
 /obj/structure/closet/secure_closet/freezer/meat{
+	anchored = 1;
 	name = "\"meat\" fridge"
 	},
 /obj/item/reagent_containers/food/snacks/meat/slab/bear,
@@ -116,7 +117,9 @@
 /turf/open/floor/plasteel/freezer,
 /area/shuttle/transport)
 "t" = (
-/obj/structure/closet/chefcloset,
+/obj/structure/closet/chefcloset{
+	anchored = 1
+	},
 /turf/open/floor/plasteel/freezer,
 /area/shuttle/transport)
 "u" = (

--- a/_maps/shuttles/hunter_russian.dmm
+++ b/_maps/shuttles/hunter_russian.dmm
@@ -74,6 +74,7 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate{
+	anchored = 1;
 	icon_state = "crateopen"
 	},
 /turf/open/floor/plating,
@@ -98,6 +99,7 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/large{
+	anchored = 1;
 	icon_state = "crittercrate"
 	},
 /turf/open/floor/plating,
@@ -136,6 +138,7 @@
 "B" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate{
+	anchored = 1;
 	icon_state = "crateopen"
 	},
 /turf/open/floor/plating,
@@ -162,6 +165,7 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/engineering{
+	anchored = 1;
 	icon_state = "engi_crateopen"
 	},
 /turf/open/floor/plating,

--- a/_maps/shuttles/hunter_space_cop.dmm
+++ b/_maps/shuttles/hunter_space_cop.dmm
@@ -63,7 +63,9 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/hunter)
 "aj" = (
-/obj/structure/closet/crate/eva,
+/obj/structure/closet/crate/eva{
+	anchored = 1
+	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/hunter)

--- a/_maps/shuttles/labour_box.dmm
+++ b/_maps/shuttles/labour_box.dmm
@@ -96,7 +96,9 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/labor)
 "p" = (
-/obj/structure/closet/crate,
+/obj/structure/closet/crate{
+	anchored = 1
+	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/labor)
 "q" = (

--- a/_maps/shuttles/labour_cog.dmm
+++ b/_maps/shuttles/labour_cog.dmm
@@ -24,7 +24,9 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/labor)
 "d" = (
-/obj/structure/closet/crate/internals,
+/obj/structure/closet/crate/internals{
+	anchored = 1
+	},
 /obj/item/clothing/suit/hazardvest{
 	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
 	name = "emergency lifejacket"

--- a/_maps/shuttles/labour_delta.dmm
+++ b/_maps/shuttles/labour_delta.dmm
@@ -221,7 +221,9 @@
 	name = "protective hat";
 	pixel_y = 9
 	},
-/obj/structure/closet/crate/internals,
+/obj/structure/closet/crate/internals{
+	anchored = 1
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,

--- a/_maps/shuttles/labour_kilo.dmm
+++ b/_maps/shuttles/labour_kilo.dmm
@@ -157,7 +157,9 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/labor)
 "r" = (
-/obj/structure/closet/crate,
+/obj/structure/closet/crate{
+	anchored = 1
+	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/mineral/titanium/yellow,

--- a/_maps/shuttles/mining_box.dmm
+++ b/_maps/shuttles/mining_box.dmm
@@ -46,7 +46,9 @@
 /turf/open/floor/plating,
 /area/shuttle/mining)
 "i" = (
-/obj/structure/closet/crate,
+/obj/structure/closet/crate{
+	anchored = 1
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/mining)
 "j" = (

--- a/_maps/shuttles/mining_common_kilo.dmm
+++ b/_maps/shuttles/mining_common_kilo.dmm
@@ -107,7 +107,9 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/mining)
 "o" = (
-/obj/structure/closet/crate,
+/obj/structure/closet/crate{
+	anchored = 1
+	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/airalarm{
 	dir = 4;

--- a/_maps/shuttles/mining_common_meta.dmm
+++ b/_maps/shuttles/mining_common_meta.dmm
@@ -46,7 +46,9 @@
 /turf/open/floor/plating,
 /area/shuttle/mining)
 "i" = (
-/obj/structure/closet/crate,
+/obj/structure/closet/crate{
+	anchored = 1
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/mining)
 "j" = (

--- a/_maps/shuttles/mining_delta.dmm
+++ b/_maps/shuttles/mining_delta.dmm
@@ -246,7 +246,9 @@
 	name = "protective hat";
 	pixel_y = 9
 	},
-/obj/structure/closet/crate/internals,
+/obj/structure/closet/crate/internals{
+	anchored = 1
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/pickaxe/emergency,
 /obj/item/pickaxe/emergency,

--- a/_maps/shuttles/mining_kilo.dmm
+++ b/_maps/shuttles/mining_kilo.dmm
@@ -155,7 +155,9 @@
 	name = "protective hat";
 	pixel_y = 9
 	},
-/obj/structure/closet/crate/internals,
+/obj/structure/closet/crate/internals{
+	anchored = 1
+	},
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -22

--- a/_maps/shuttles/mining_large.dmm
+++ b/_maps/shuttles/mining_large.dmm
@@ -300,7 +300,9 @@
 	name = "protective hat";
 	pixel_y = 9
 	},
-/obj/structure/closet/crate/internals,
+/obj/structure/closet/crate/internals{
+	anchored = 1
+	},
 /obj/item/pickaxe/emergency,
 /obj/item/pickaxe/emergency,
 /obj/effect/turf_decal/box/white/corners{

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -320,6 +320,15 @@
 	addtimer(CALLBACK(src, /datum.proc/_AddElement, list(/datum/element/beauty, 500)), 0)
 	AddComponent(/datum/component/two_handed, require_twohands=TRUE, force_unwielded=10, force_wielded=10)
 
+/obj/item/kirbyplants/attackby(obj/item/I, mob/living/user, params)
+	. = ..()
+	if(I.tool_behaviour == TOOL_SCREWDRIVER)
+		I.play_tool_sound(src, 100)
+		user.visible_message(anchored ? span_notice("[user] unscrews \the [src] from the floor.") : span_notice("[user] screws \the [src] to the floor."),
+			anchored ? span_notice("You unscrew \the [src] from the floor.") : span_notice("You screw \the [src] to the floor.")
+		)
+		set_anchored(!anchored)
+
 /obj/item/kirbyplants/random
 	icon = 'icons/obj/flora/_flora.dmi'
 	icon_state = "random_plant"


### PR DESCRIPTION
## About The Pull Request

Title, you anchor with a screwdriver.
Also anchors a *LOT* of things on the shuttles, since we have them throw people on launch/land.

## Why It's Good For The Game

Flying potted plant monster.

## Pre-Merge Checklist:
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.

## Changelog
:cl:
add: plants are now screwable to the floor
tweak: most of shuttle contents are now properly anchored to the floor
/:cl:
